### PR TITLE
Enforce strict tool payload schema and align web env

### DIFF
--- a/serving/ToolGRPOTrainer/azure_command_sender.py
+++ b/serving/ToolGRPOTrainer/azure_command_sender.py
@@ -2,6 +2,7 @@ import os
 import json
 import asyncio
 import logging
+from typing import Any, Dict
 from uuid import uuid4
 from dotenv import load_dotenv
 from servicebus_web import ServiceBusQueueWeb
@@ -14,7 +15,7 @@ WEB_QUEUE_NAME = os.getenv("QUEUE_NAME", "commandqueue")  # queue to send comman
 REWARD_QUEUE_NAME = os.getenv("REWARD_QUEUE_NAME", "rewardqueue")  # queue to receive results
 
 
-def send_azure_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
+def send_azure_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:
     """Send an azure tool command to Service Bus and wait briefly for a response from reward queue.
 
     Flow:
@@ -25,8 +26,12 @@ def send_azure_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
     if not SERVICE_BUS_CONNECTION_STRING:
         return "[azure-error] Missing SERVICE_BUS_CONNECTION_STRING env var"
 
+    command = str(payload.get("azure_command", "")).strip()
+    if not command:
+        return "[azure-error] Empty azure command"
+
     request_id = str(uuid4())
-    message = {"azure_command": payload, "request_id": request_id, "type": "azure_command"}
+    message = {"azure_command": command, "request_id": request_id, "type": "azure_command"}
 
     try:
         # Send request (re-using send_web_result for simplicity)

--- a/serving/ToolGRPOTrainer/code_command_sender.py
+++ b/serving/ToolGRPOTrainer/code_command_sender.py
@@ -2,6 +2,7 @@ import os
 import json
 import asyncio
 import logging
+from typing import Any, Dict
 from uuid import uuid4
 from dotenv import load_dotenv
 from servicebus_web import ServiceBusQueueWeb
@@ -14,7 +15,7 @@ WEB_QUEUE_NAME = os.getenv("QUEUE_NAME", "commandqueue")  # queue to send comman
 REWARD_QUEUE_NAME = os.getenv("REWARD_QUEUE_NAME", "rewardqueue")  # queue to receive results
 
 
-def send_code_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
+def send_code_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:
     """Send a code tool command to Service Bus and wait briefly for a response from reward queue.
 
     Flow:
@@ -25,8 +26,12 @@ def send_code_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
     if not SERVICE_BUS_CONNECTION_STRING:
         return "[code-error] Missing SERVICE_BUS_CONNECTION_STRING env var"
 
+    command = str(payload.get("code_command", "")).strip()
+    if not command:
+        return "[code-error] Empty code command"
+
     request_id = str(uuid4())
-    message = {"code_command": payload, "request_id": request_id, "type": "code_command"}
+    message = {"code_command": command, "request_id": request_id, "type": "code_command"}
 
     try:
         # Send request (re-using send_web_result for simplicity)

--- a/serving/ToolGRPOTrainer/command_sender.py
+++ b/serving/ToolGRPOTrainer/command_sender.py
@@ -2,6 +2,7 @@ import os
 import json
 import asyncio
 import logging
+from typing import Any, Dict
 from uuid import uuid4
 from dotenv import load_dotenv
 from servicebus_web import ServiceBusQueueWeb
@@ -14,7 +15,7 @@ WEB_QUEUE_NAME = os.getenv("QUEUE_NAME", "commandqueue")  # queue to send comman
 REWARD_QUEUE_NAME = os.getenv("REWARD_QUEUE_NAME", "rewardqueue")  # queue to receive results
 
 
-def send_web_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
+def send_web_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:
     """Send a web tool command to Service Bus and wait briefly for a response from reward queue.
 
     Flow:
@@ -25,8 +26,17 @@ def send_web_command(payload: str, k: int = 3, timeout_s: int = 10) -> str:
     if not SERVICE_BUS_CONNECTION_STRING:
         return "[web-error] Missing SERVICE_BUS_CONNECTION_STRING env var"
 
+    q = str(payload.get("q", "")).strip()
+    if not q:
+        return "[web-error] Empty web query"
+    k_val = payload.get("k", 3)
+    try:
+        k = int(k_val)
+    except (TypeError, ValueError):
+        k = 3
+
     request_id = str(uuid4())
-    message = {"q": payload, "k": k, "request_id": request_id, "type": "web_command"}
+    message = {"q": q, "k": k, "request_id": request_id, "type": "web_command"}
 
     try:
         # Send request (re-using send_web_result for simplicity)

--- a/serving/ToolGRPOTrainer/custom_grpo.py
+++ b/serving/ToolGRPOTrainer/custom_grpo.py
@@ -39,16 +39,27 @@ warnings.filterwarnings("ignore", message=".*Caching is incompatible with gradie
 def run_web_tool(payload: str) -> str:
     print(f"[TOOL][web] payload={payload!r}")
     # Validate and normalize to the exact format the container expects
-    web = ensure_web_payload(payload, default_k=3)  # => {"q": str, "k": int}
-    return send_web_command(web["q"], k=int(web.get("k", 3)), timeout_s=15)
+    try:
+        web = ensure_web_payload(payload, default_k=3)  # => {"q": str, "k": int}
+    except Exception as exc:
+        return f"[web-error] {exc}"
+    return send_web_command(web, timeout_s=15)
 
 def run_code_tool(payload: str) -> str:
     print(f"[TOOL][code] payload={payload!r}")
-    return f"[code-result] executed: {payload} - Output: Hello, World!"
+    try:
+        code_payload = ensure_code_payload(payload)
+    except Exception as exc:
+        return f"[code-error] {exc}"
+    return send_code_command(code_payload, timeout_s=15)
 
 def run_azure_tool(payload: str) -> str:
     print(f"[TOOL][azure] payload={payload!r}")
-    return f"[azure-result] ran: {payload} - Status: Operation completed successfully"
+    try:
+        azure_payload = ensure_azure_payload(payload)
+    except Exception as exc:
+        return f"[azure-error] {exc}"
+    return send_azure_command(azure_payload, timeout_s=15)
 
 # -------------------------------
 # Custom Trainer with streaming rollouts

--- a/serving/ToolGRPOTrainer/run_custom_grpo.py
+++ b/serving/ToolGRPOTrainer/run_custom_grpo.py
@@ -17,18 +17,23 @@ WE HAVE OPTIMIZE THE PROMPT AND MAKE SURE IT USES THE PROMPT IN THE .env fle
 '''
 SYSTEM_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
-    "You are a helpful AI assistant with access to three tools.\n"
-    "Tools: <web>{query}</web> for web search. <code>{code}</code> to run code (JSON with cmd,cwd,timeout_s). <azure>{azure}</azure> for Azure CLI (JSON with args list).\n"
-    "Decide if a tool is needed BEFORE answering. If you use a tool, emit only the tool tag, wait for <tool_result> then continue reasoning. Finish final answer inside <solution>...</solution>."
+    (
+        "You are a helpful AI assistant with access to three tools.\n"
+        "Use STRICT JSON payloads inside tool tags:\n"
+        '- <web>{"q": "search terms", "k": NUMBER}</web>\n'
+        '- <code>{"code_command": "shell command"}</code>\n'
+        '- <azure>{"azure_command": "azure cli command"}</azure>\n'
+        "Decide if a tool is needed BEFORE answering. If you use a tool, emit only the tool tag, wait for <tool_result> then continue reasoning. Finish final answer inside <solution>...</solution>."
+    )
 )
 
 USER_TASKS = [
     # Force explicit web tool call (restored explicit tag)
     "Find the latest stable Python version via the web tool then give final answer",
     # Force explicit code tool call
-    "Write and execute Python code to print the sum of the first 5 integers: <code>{\"cmd\": \"python -c 'print(sum(range(1,6)))'\", \"cwd\": \".\", \"timeout_s\": 5}</code> then confirm the result.",
+    "Write and execute Python code to print the sum of the first 5 integers: <code>{\"code_command\": \"python -c 'print(sum(range(1,6)))'\"}</code> then confirm the result.",
     # Force explicit azure tool call
-    "Simulate an Azure CLI docs lookup using the azure tool: <azure>{\"args\": [\"az account show --query name -o tsv\"]}</azure> then summarize what it does.",
+    "Simulate an Azure CLI docs lookup using the azure tool: <azure>{\"azure_command\": \"az account show --query name -o tsv\"}</azure> then summarize what it does.",
 ]
 
 # Wrap prompts similarly to run_grpo.py so formatting is consistent

--- a/serving/parser.py
+++ b/serving/parser.py
@@ -7,21 +7,39 @@ import re
 from typing import List, Dict, Any, Tuple
 
 
+def _extract_tag(content: str, tag: str) -> List[Tuple[int, str]]:
+    """Return list of (start_index, inner_text) for each completed tag occurrence."""
+    open_tag = f"<{tag}>"
+    close_tag = f"</{tag}>"
+    matches: List[Tuple[int, str]] = []
+    search_pos = 0
+    while True:
+        start = content.find(open_tag, search_pos)
+        if start == -1:
+            break
+        end = content.find(close_tag, start + len(open_tag))
+        if end == -1:
+            break
+        inner = content[start + len(open_tag):end]
+        matches.append((start, inner))
+        search_pos = end + len(close_tag)
+    return matches
+
+
 def stream_parser(buffer: str):
     """
     Detect complete tool tags in a streaming buffer.
     Returns {"type": tool_type, "content": payload} if found, else None.
     """
-    patterns = {
-        "web": r"<web>(.*?)</web>",
-        "code": r"<code>(.*?)</code>",
-        "azure": r"<azure>(.*?)</azure>",
-    }
-    for ttype, pat in patterns.items():
-        match = re.search(pat, buffer, re.DOTALL)
-        if match:
-            content = match.group(1).strip()
-            return {"type": ttype, "content": content}
+    earliest = None
+    for tool in ("web", "code", "azure"):
+        matches = _extract_tag(buffer, tool)
+        if matches:
+            start, inner = matches[0]
+            if earliest is None or start < earliest[0]:
+                earliest = (start, tool, inner.strip())
+    if earliest:
+        return {"type": earliest[1], "content": earliest[2]}
     return None
 
 
@@ -46,14 +64,9 @@ def parse_thinking_tags(content: str) -> Tuple[str, str, str]:
 def parse_tool_tags(content: str) -> List[Dict[str, Any]]:
     """Return list of tool calls with type and content."""
     tool_calls = []
-    for tool_type, pattern in {
-        "web": r'<web>(.*?)</web>',
-        "code": r'<code>(.*?)</code>',
-        "azure": r'<azure>(.*?)</azure>',
-    }.items():
-        matches = re.findall(pattern, content, re.DOTALL)
-        for match in matches:
-            tool_calls.append({"type": tool_type, "content": match.strip()})
+    for tool_type in ("web", "code", "azure"):
+        for _, inner in _extract_tag(content, tool_type):
+            tool_calls.append({"type": tool_type, "content": inner.strip()})
     return tool_calls
 
 
@@ -79,8 +92,8 @@ def validate_tool_schema(tool_type: str, tool_data: Dict[str, Any]) -> bool:
         return False
     schemas = {
         "web": ["q", "k"],
-        "code": ["cmd", "cwd", "timeout_s"],
-        "azure": ["args"],
+        "code": ["code_command"],
+        "azure": ["azure_command"],
     }
     required = schemas.get(tool_type)
     if required is None:

--- a/serving/run_model.py
+++ b/serving/run_model.py
@@ -7,6 +7,7 @@ from parser import stream_parser
 from ToolGRPOTrainer.command_sender import send_web_command
 from ToolGRPOTrainer.azure_command_sender import send_azure_command
 from ToolGRPOTrainer.code_command_sender import send_code_command
+from validation import ensure_web_payload, ensure_code_payload, ensure_azure_payload
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -18,15 +19,27 @@ load_dotenv()
 # Tool execution functions
 def run_web_tool(payload: str) -> str:
     print(f"[TOOL][web] payload={payload!r}")
-    return send_web_command(payload, k=3, timeout_s=15)
+    try:
+        web_payload = ensure_web_payload(payload)
+    except Exception as exc:
+        return f"[web-error] {exc}"
+    return send_web_command(web_payload, timeout_s=15)
 
 def run_code_tool(payload: str) -> str:
     print(f"[TOOL][code] payload={payload!r}")
-    return send_code_command(payload, timeout_s=15)
+    try:
+        code_payload = ensure_code_payload(payload)
+    except Exception as exc:
+        return f"[code-error] {exc}"
+    return send_code_command(code_payload, timeout_s=15)
 
 def run_azure_tool(payload: str) -> str:
     print(f"[TOOL][azure] payload={payload!r}")
-    return send_azure_command(payload, timeout_s=15)
+    try:
+        azure_payload = ensure_azure_payload(payload)
+    except Exception as exc:
+        return f"[azure-error] {exc}"
+    return send_azure_command(azure_payload, timeout_s=15)
 
 # Load environment variables from .env file
 load_dotenv()
@@ -80,6 +93,12 @@ ALLOWED TAGS ONLY
 - <azure>...</azure> — whitelisted Azure CLI subcommands.
 - <solution>...</solution> — final answer for the user.
 Do not use any other tags, formats, or tools.
+
+TOOL PAYLOAD FORMAT (MANDATORY)
+- <web> content MUST be JSON exactly like {"q": "search terms", "k": INTEGER}. Provide the desired search in "q" and a numeric top-k in "k".
+- <code> content MUST be JSON exactly like {"code_command": "shell command"}.
+- <azure> content MUST be JSON exactly like {"azure_command": "azure cli command"}.
+Do not include extra keys or text inside tool tags.
 
 TURN PROTOCOL (STRICT)
 1) In <think>, decide exactly ONE next action and why.

--- a/serving/validation.py
+++ b/serving/validation.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
 import json
-import shlex
-from typing import Any, Dict, List, Union, Optional
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from typing import Any, Dict, Union
+from pydantic import BaseModel, Field
+
+
+def _as_dict(payload: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Coerce a tool payload into a dictionary."""
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, str):
+        text = payload.strip()
+        if not text:
+            raise ValueError("Tool payload cannot be empty")
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Tool payload must be JSON: {exc}")
+        if not isinstance(data, dict):
+            raise ValueError("Tool payload must decode to an object")
+        return data
+    raise ValueError("Tool payload must be a dict or JSON object string")
 
 
 class WebCommand(BaseModel):
@@ -12,100 +29,48 @@ class WebCommand(BaseModel):
 
     @classmethod
     def coerce(cls, payload: Union[str, Dict[str, Any]], default_k: int = 3) -> "WebCommand":
-        # If string, try JSON first; otherwise treat as raw query
-        if isinstance(payload, str):
-            text = payload.strip()
-            if text.startswith("{") and text.endswith("}"):
-                try:
-                    data = json.loads(text)
-                    return cls(q=str(data.get("q", "")).strip(), k=int(data.get("k", default_k)))
-                except Exception:
-                    pass
-            return cls(q=text, k=default_k)
-        elif isinstance(payload, dict):
-            q = payload.get("q") or payload.get("query") or payload.get("raw_content")
-            k = payload.get("k", default_k)
-            return cls(q=str(q or "").strip(), k=int(k))
-        else:
-            raise ValidationError(["Unsupported payload type for WebCommand"])
+        data = _as_dict(payload)
+        q = str(data.get("q", "")).strip()
+        k_raw = data.get("k", default_k)
+        try:
+            k = int(k_raw)
+        except (TypeError, ValueError):
+            k = default_k
+        return cls(q=q, k=k)
 
 
 class CodeCommand(BaseModel):
-    cmd: str = Field(..., min_length=1, description="Shell command to run")
-    cwd: Optional[str] = Field(None, description="Working directory")
-    timeout_s: int = Field(15, ge=1, le=900, description="Timeout in seconds")
+    code_command: str = Field(..., min_length=1, description="Code command string")
 
     @classmethod
-    def coerce(cls, payload: Union[str, Dict[str, Any]], default_timeout: int = 15) -> "CodeCommand":
-        if isinstance(payload, str):
-            text = payload.strip()
-            if text.startswith("{") and text.endswith("}"):
-                try:
-                    data = json.loads(text)
-                    return cls(
-                        cmd=str(data.get("cmd", "")).strip(),
-                        cwd=data.get("cwd"),
-                        timeout_s=int(data.get("timeout_s", default_timeout)),
-                    )
-                except Exception:
-                    pass
-            return cls(cmd=text, timeout_s=default_timeout)
-        elif isinstance(payload, dict):
-            return cls(
-                cmd=str(payload.get("cmd", "")).strip(),
-                cwd=payload.get("cwd"),
-                timeout_s=int(payload.get("timeout_s", default_timeout)),
-            )
-        else:
-            raise ValidationError(["Unsupported payload type for CodeCommand"])
+    def coerce(cls, payload: Union[str, Dict[str, Any]]) -> "CodeCommand":
+        data = _as_dict(payload)
+        command = str(data.get("code_command", "")).strip()
+        return cls(code_command=command)
 
 
 class AzureCommand(BaseModel):
-    args: List[str] = Field(..., min_length=1, description="Azure CLI arguments list")
-
-    @field_validator("args")
-    @classmethod
-    def _strip_args(cls, v: List[str]) -> List[str]:
-        return [str(a).strip() for a in v if str(a).strip()]
+    azure_command: str = Field(..., min_length=1, description="Azure command string")
 
     @classmethod
     def coerce(cls, payload: Union[str, Dict[str, Any]]) -> "AzureCommand":
-        if isinstance(payload, str):
-            text = payload.strip()
-            if text.startswith("{") and text.endswith("}"):
-                try:
-                    data = json.loads(text)
-                    args = data.get("args")
-                    if isinstance(args, list):
-                        return cls(args=[str(a) for a in args])
-                except Exception:
-                    pass
-            # best-effort split into tokens
-            return cls(args=shlex.split(text))
-        elif isinstance(payload, dict):
-            args = payload.get("args")
-            if isinstance(args, list):
-                return cls(args=[str(a) for a in args])
-            # fallback if someone used raw_content
-            rc = payload.get("raw_content")
-            if isinstance(rc, str):
-                return cls(args=shlex.split(rc))
-            raise ValidationError(["Missing 'args' for AzureCommand"])
-        else:
-            raise ValidationError(["Unsupported payload type for AzureCommand"])
+        data = _as_dict(payload)
+        command = str(data.get("azure_command", "")).strip()
+        return cls(azure_command=command)
 
 
 def ensure_web_payload(payload: Union[str, Dict[str, Any]], default_k: int = 3) -> Dict[str, Any]:
     model = WebCommand.coerce(payload, default_k=default_k)
-    return model.model_dump()
+    result = model.model_dump()
+    return {"q": result["q"], "k": result["k"]}
 
 
-def ensure_code_payload(payload: Union[str, Dict[str, Any]], default_timeout: int = 15) -> Dict[str, Any]:
-    model = CodeCommand.coerce(payload, default_timeout=default_timeout)
-    return model.model_dump()
+def ensure_code_payload(payload: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    model = CodeCommand.coerce(payload)
+    return {"code_command": model.code_command}
 
 
 def ensure_azure_payload(payload: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     model = AzureCommand.coerce(payload)
-    return model.model_dump()
+    return {"azure_command": model.azure_command}
 

--- a/web-rl-env/src/main.py
+++ b/web-rl-env/src/main.py
@@ -2,7 +2,7 @@ import os, json, asyncio, logging
 from typing import Optional, Any, Dict, List
 from fastapi import FastAPI
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from azure.servicebus import ServiceBusClient, ServiceBusMessage, TransportType
 from azure.servicebus.aio import ServiceBusClient as AioServiceBusClient
 from .command_queue import CommandQueue
@@ -18,9 +18,13 @@ load_dotenv()
 app = FastAPI(title="Simple Web RL Environment", version="0.2.3")
 
 class CommandRequest(BaseModel):
-    command_type: str
+    command_type: Optional[str] = None
     action: Optional[Any] = None
     parameters: Optional[dict] = None
+    q: Optional[str] = None
+    k: Optional[int] = None
+
+    model_config = ConfigDict(extra="allow")
 
 
 class RewardRequest(BaseModel):
@@ -97,7 +101,8 @@ async def receive_command(command: CommandRequest):
     try:
         # 1) Send to Service Bus (keep original behavior)
         msg_id = str(uuid4())
-        payload = json.dumps(command.dict())
+        payload_dict = command.model_dump(exclude_none=True)
+        payload = json.dumps(payload_dict)
         message = ServiceBusMessage(payload, message_id=msg_id)
         with servicebus_client:
             with servicebus_client.get_queue_sender(COMMAND_QUEUE_NAME) as sender:
@@ -108,7 +113,7 @@ async def receive_command(command: CommandRequest):
         k = None
         # Prefer a top-level `data` shape if present in action/parameters
         # This keeps compatibility with the CommandQueue parser
-        body_dict = command.dict()
+        body_dict = payload_dict
         # a) Directly in parameters
         if isinstance(body_dict.get("parameters"), dict):
             params = body_dict["parameters"]
@@ -118,6 +123,11 @@ async def receive_command(command: CommandRequest):
         if q is None and isinstance(body_dict.get("action"), dict):
             q = body_dict["action"].get("q", q)
             k = body_dict["action"].get("k", k)
+        # c) Allow direct top-level q/k
+        if q is None and body_dict.get("q") is not None:
+            q = body_dict.get("q")
+        if k is None and body_dict.get("k") is not None:
+            k = body_dict.get("k")
 
         # 3) If not found, poll the in-memory `/read-command` view briefly
         #    to leverage the parsed content from CommandQueue

--- a/web-rl-env/src/parser.py
+++ b/web-rl-env/src/parser.py
@@ -26,24 +26,35 @@ def parse_received_command(obj: Union[str, Dict[str, Any]]) -> Optional[Dict[str
     return None
 
 
+def _extract_from_mapping(mapping: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(mapping, dict):
+        return None
+    q = mapping.get("q")
+    k = mapping.get("k")
+    if q is None and k is None:
+        return None
+    return {"q": q, "k": k}
+
+
 def extract_qk_from_data(received_command: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """
     Given a parsed received_command dict, extract the `q` and `k` fields
-    from its `data` object, if present. Returns None if unavailable.
+    regardless of whether they are top-level or nested inside "data".
+    Returns None if unavailable.
     """
     if not isinstance(received_command, dict):
         return None
 
-    data = received_command.get("data")
-    if not isinstance(data, dict):
-        return None
+    direct = _extract_from_mapping(received_command)
+    if direct:
+        return direct
 
-    q = data.get("q")
-    k = data.get("k")
-    if q is None and k is None:
-        return None
+    for key in ("data", "action", "parameters"):
+        nested = _extract_from_mapping(received_command.get(key))
+        if nested:
+            return nested
 
-    return {"q": q, "k": k}
+    return None
 
 
 def parse_read_command_payload(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -62,5 +73,9 @@ def parse_read_command_payload(payload: Dict[str, Any]) -> Optional[Dict[str, An
         raw = payload.get("raw_content")
         parsed = parse_received_command(raw)
 
-    return extract_qk_from_data(parsed)
+    extracted = extract_qk_from_data(parsed)
+    if extracted:
+        return extracted
+
+    return extract_qk_from_data(payload)
 


### PR DESCRIPTION
## Summary
- update the serving runtime and GRPO prompts to spell out the exact JSON payloads required for <web>, <code>, and <azure> tool tags and add defensive validation before dispatching commands
- simplify tool payload validation into lean Pydantic models, tighten parser schema checks, and make the Service Bus senders consume the normalized dictionaries
- let the web RL environment accept top-level {q, k} payloads by widening its request model and extractor so the queue and HTTP paths agree on the minimal schema

## Testing
- python -m compileall serving web-rl-env/src

------
https://chatgpt.com/codex/tasks/task_e_68c9abdb0a14832586a2ffd09f80110b