### PR TITLE
Ensure reward subscription fallback to command defaults

### DIFF
--- a/serving/communication/azure_command_sender.py
+++ b/serving/communication/azure_command_sender.py
@@ -14,7 +14,7 @@ SERVICE_BUS_CONNECTION_STRING = os.getenv("SERVICE_BUS_CONNECTION_STRING")
 WEB_TOPIC_NAME = os.getenv("COMMAND_TOPIC_NAME", "commandtopic")  # topic to send commands
 REWARD_TOPIC_NAME = os.getenv("REWARD_TOPIC_NAME", "rewardtopic")  # topic to receive results
 SUBSCRIPTION_NAME = os.getenv("WEB_SUBSCRIPTION_NAME", "rlcommandbustopic")
-REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME")
+REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME") or SUBSCRIPTION_NAME
 
 
 def send_azure_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:
@@ -47,7 +47,11 @@ def send_azure_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:
     async def _wait_for_response():
         for _ in range(timeout_s):
             try:
-                reward_topic = ServiceBusTopic(SERVICE_BUS_CONNECTION_STRING, topic_name=REWARD_TOPIC_NAME, subscription_name=REWARD_SUBSCRIPTION_NAME
+                reward_topic = ServiceBusTopic(
+                    SERVICE_BUS_CONNECTION_STRING,
+                    topic_name=REWARD_TOPIC_NAME,
+                    subscription_name=REWARD_SUBSCRIPTION_NAME,
+                )
                 resp = await reward_topic.receive_web_reward_async()
                 if resp and resp.get("message") not in {"No rewards received", "No messages received"}:
                     return resp

--- a/serving/communication/code_command_sender.py
+++ b/serving/communication/code_command_sender.py
@@ -14,7 +14,7 @@ SERVICE_BUS_CONNECTION_STRING = os.getenv("SERVICE_BUS_CONNECTION_STRING")
 WEB_TOPIC_NAME = os.getenv("COMMAND_TOPIC_NAME", "commandtopic")  # topic to send commands
 REWARD_TOPIC_NAME = os.getenv("REWARD_TOPIC_NAME", "rewardtopic")  # topic to receive results
 CODE_SUBSCRIPTION_NAME = os.getenv("CODE_SUBSCRIPTION_NAME", "codesubscription")  # command subscription
-REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME")
+REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME") or CODE_SUBSCRIPTION_NAME
 
 
 def send_code_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:

--- a/serving/communication/command_sender.py
+++ b/serving/communication/command_sender.py
@@ -14,7 +14,7 @@ SERVICE_BUS_CONNECTION_STRING = os.getenv("SERVICE_BUS_CONNECTION_STRING")
 WEB_TOPIC_NAME = os.getenv("COMMAND_TOPIC_NAME", "commandtopic")  # topic to send commands
 REWARD_TOPIC_NAME = os.getenv("REWARD_TOPIC_NAME", "rewardtopic")  # topic to receive results
 SUBSCRIPTION_NAME = os.getenv("WEB_SUBSCRIPTION_NAME", "rlcommandbustopic")  # command subscription (if distinct)
-REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME")
+REWARD_SUBSCRIPTION_NAME = os.getenv("REWARD_SUBSCRIPTION_NAME") or SUBSCRIPTION_NAME
 
 
 def send_web_command(payload: Dict[str, Any], timeout_s: int = 10) -> str:


### PR DESCRIPTION
## Summary
- default reward subscription to the command/code subscription when a dedicated value is not provided
- fix the Azure command sender to construct the reward topic helper correctly

## Testing
- python -m compileall serving/communication

------
https://chatgpt.com/codex/tasks/task_e_68d4ee742e6c8325956d825300a74404