### PR TITLE
Add in-memory BufferQueue for async generator-trainer communication

### DIFF
--- a/serving/DisGenerator/batch_orchestrator.py
+++ b/serving/DisGenerator/batch_orchestrator.py
@@ -32,6 +32,9 @@ from reward_functions import compute_reward
 # PolicyManager for hot-swapping LoRA adapters
 from policy_manager import PolicyManager
 
+# BufferQueue: in-memory async deque shared with the trainer
+from buffer_queue import BufferQueue
+
 # Tokenizer for proper token ID extraction
 from transformers import AutoTokenizer
 
@@ -56,7 +59,21 @@ class Trajectory:
     expected_answer: str = ""
 
 class AsyncBatchOrchestrator:
-    def __init__(self, proxy_url: str, model: str = "Qwen/Qwen3-4B-Thinking-2507", tokenizer_name: str = "Qwen/Qwen3-4B-Thinking-2507", num_gpu_workers: int = 4, num_tool_workers: int = 32, output_dir: str = None, batch_size: int = 10, num_completions_per_prompt: int = 4, generation_temperature: float = 1.0, enabled_tools: Optional[Iterable[str]] = None, policy_manager: Optional[PolicyManager] = None):
+    def __init__(
+        self,
+        proxy_url: str,
+        model: str = "Qwen/Qwen3-4B-Thinking-2507",
+        tokenizer_name: str = "Qwen/Qwen3-4B-Thinking-2507",
+        num_gpu_workers: int = 4,
+        num_tool_workers: int = 32,
+        output_dir: str = None,
+        batch_size: int = 10,
+        num_completions_per_prompt: int = 4,
+        generation_temperature: float = 1.0,
+        enabled_tools: Optional[Iterable[str]] = None,
+        policy_manager: Optional[PolicyManager] = None,
+        buffer_queue: Optional[BufferQueue] = None,
+    ):
         self.proxy_url = proxy_url
         self.model = model  # Can be base model or LoRA adapter name
         self.task_queue = asyncio.Queue()  # For GPU tasks
@@ -65,38 +82,50 @@ class AsyncBatchOrchestrator:
 
         # PolicyManager for hot-swapping LoRA adapters (optional)
         self.policy_manager = policy_manager
-        
-        # Output configuration - save as batch files to DisTrainer
-        if output_dir is None:
-            # Default to DisTrainer's data/generations folder
-            output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../DisTrainer/data/generations"))
-        self.output_dir = ensure_output_dir(output_dir)
-        self.batch_counter = get_next_batch_number(self.output_dir)
+
+        # BufferQueue: when provided, completed groups are pushed here instead of
+        # being written to disk.  Falls back to file-based output when None.
+        self.buffer_queue = buffer_queue
+
+        # File-based output (used only when buffer_queue is None)
+        if buffer_queue is None:
+            if output_dir is None:
+                output_dir = os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), "../DisTrainer/data/generations")
+                )
+            self.output_dir = ensure_output_dir(output_dir)
+            self.batch_counter = get_next_batch_number(self.output_dir)
+        else:
+            # Keep output_dir around in case flush_pending is called without a queue
+            self.output_dir = output_dir
+            self.batch_counter = 0
+
         self._batch_lock = asyncio.Lock()
-        
-        # Batch accumulation - collect N complete GROUPS (prompts) before writing
-        # batch_size now refers to number of PROMPTS, not trajectories
-        # e.g., batch_size=10 with num_completions_per_prompt=4 = 40 trajectories per batch
-        self.batch_size = batch_size  # Number of prompts per batch file
+
+        # Batch accumulation – collect N complete GROUPS (prompts) before flushing.
+        # With buffer_queue: each complete group is pushed immediately (batch_size
+        # is still used by flush_pending for leftover groups written to disk).
+        # Without buffer_queue: batch_size groups are written to one JSONL file.
+        self.batch_size = batch_size  # Number of prompts per batch file (file mode)
         self._pending_groups: Dict[str, List[Dict]] = {}  # group_id -> list of records
-        
+
         # GRPO configuration
         self.num_completions_per_prompt = num_completions_per_prompt
         self.generation_temperature = generation_temperature
-        
+
         self.num_gpu_workers = num_gpu_workers
         self.num_tool_workers = num_tool_workers
         self.workers: List[asyncio.Task] = []
-        
+
         # Initialize tokenizer for proper token ID extraction
         logger.info(f"Loading tokenizer: {tokenizer_name}")
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
         logger.info(f"Tokenizer loaded. Vocab size: {len(self.tokenizer)}")
-        
+
         # Stop strings for vLLM to pause generation immediately on tool call
         self.tool_stop_tokens = [f"</{tool}>" for tool in self.enabled_tools]
         self.stop_tokens = [*self.tool_stop_tokens, "</solution>"]
-        
+
         # Context window configuration
         self.max_model_len = 65536  # Model's max context length (64K)
         self.min_completion_tokens = 256  # Minimum tokens to reserve for completion
@@ -190,94 +219,125 @@ class AsyncBatchOrchestrator:
         # Accumulate record by group_id for GRPO grouping
         async with self._batch_lock:
             group_id = record.get("group_id", traj.id)
-            
+
             # Add to pending group
             if group_id not in self._pending_groups:
                 self._pending_groups[group_id] = []
             self._pending_groups[group_id].append(record)
-            
-            # Check if this group is now complete
+
             group_size = len(self._pending_groups[group_id])
             logger.info(f"[Group {group_id}] Completion {group_size}/{self.num_completions_per_prompt}")
-            
-            # Count complete groups (groups with all completions)
-            complete_groups = [
-                g_id for g_id, records in self._pending_groups.items()
-                if len(records) >= self.num_completions_per_prompt
-            ]
-            
-            # When we have batch_size complete groups, write them all to a file
-            if len(complete_groups) >= self.batch_size:
-                batch_num = self.batch_counter
-                self.batch_counter += 1
-                
-                # Build grouped records (one per group with all completions)
-                grouped_records = []
-                for g_id in complete_groups[:self.batch_size]:
-                    group_records = self._pending_groups.pop(g_id)
-                    
-                    # Take prompt info from first record
+
+            # Once all completions for this group have arrived, assemble and dispatch.
+            if group_size >= self.num_completions_per_prompt:
+                group_records = self._pending_groups.pop(group_id)
+                first = group_records[0]
+                grouped_record = {
+                    "group_id": group_id,
+                    "prompt": first.get("prompt"),
+                    "prompt_ids": first.get("prompt_ids"),
+                    "completions": [r.get("completion") for r in group_records],
+                    "metadata": {
+                        "num_completions": len(group_records),
+                        "timestamp": first.get("metadata", {}).get("timestamp"),
+                    },
+                }
+
+                if self.buffer_queue is not None:
+                    # ── Queue mode: push directly into the in-memory deque ──
+                    added = await self.buffer_queue.put(grouped_record)
+                    q_stats = self.buffer_queue.stats()
+                    logger.info(
+                        f"[Group {group_id}] → BufferQueue "
+                        f"(size={q_stats['size']}/{q_stats['maxlen']}, "
+                        f"evicted={'yes' if not added else 'no'})"
+                    )
+                else:
+                    # ── File mode (legacy): batch up and write to JSONL ──
+                    # Re-insert so the file-batch accumulator can see it.
+                    # We reuse _pending_groups with a sentinel key to hold
+                    # complete groups waiting for the file batch threshold.
+                    if "_ready" not in self._pending_groups:
+                        self._pending_groups["_ready"] = []
+                    self._pending_groups["_ready"].append(grouped_record)
+
+                    ready = self._pending_groups["_ready"]
+                    if len(ready) >= self.batch_size:
+                        batch_num = self.batch_counter
+                        self.batch_counter += 1
+                        grouped_records = self._pending_groups.pop("_ready")
+
+                        batch_file = os.path.join(self.output_dir, f"batch_{batch_num:05d}.jsonl")
+                        loop = asyncio.get_running_loop()
+                        await loop.run_in_executor(None, write_batch_file, batch_file, grouped_records)
+                        logger.info(
+                            f"[Batch {batch_num}] Saved {len(grouped_records)} groups "
+                            f"({self.num_completions_per_prompt} completions each) to {batch_file}"
+                        )
+                    else:
+                        logger.info(
+                            f"[Group {group_id}] Buffered for file batch "
+                            f"({len(ready)}/{self.batch_size} groups ready)"
+                        )
+            else:
+                logger.info(
+                    f"[Traj {traj.id}] Added to group {group_id}. "
+                    f"Pending completions: {group_size}/{self.num_completions_per_prompt}"
+                )
+
+    async def flush_pending(self):
+        """
+        Flush any remaining records (including incomplete groups).
+
+        Queue mode:  partial groups are pushed into the BufferQueue as-is so
+                     the trainer can still learn from them.
+        File mode:   writes a final JSONL batch to disk.
+        """
+        async with self._batch_lock:
+            if not self._pending_groups:
+                return
+
+            grouped_records = []
+
+            # Collect the "_ready" file-batch list (file mode only)
+            ready = self._pending_groups.pop("_ready", [])
+            grouped_records.extend(ready)
+
+            # Collect any partially-complete groups (all modes)
+            for g_id, group_records in self._pending_groups.items():
+                if group_records:
                     first = group_records[0]
-                    grouped_record = {
+                    grouped_records.append({
                         "group_id": g_id,
                         "prompt": first.get("prompt"),
                         "prompt_ids": first.get("prompt_ids"),
                         "completions": [r.get("completion") for r in group_records],
                         "metadata": {
                             "num_completions": len(group_records),
-                            "timestamp": first.get("metadata", {}).get("timestamp")
-                        }
-                    }
-                    grouped_records.append(grouped_record)
-                
+                            "timestamp": first.get("metadata", {}).get("timestamp"),
+                        },
+                    })
+            self._pending_groups = {}
+
+            if not grouped_records:
+                return
+
+            if self.buffer_queue is not None:
+                for gr in grouped_records:
+                    await self.buffer_queue.put(gr)
+                logger.info(
+                    f"[flush_pending] Pushed {len(grouped_records)} remaining groups "
+                    f"into BufferQueue. {self.buffer_queue}"
+                )
+            else:
+                batch_num = self.batch_counter
+                self.batch_counter += 1
                 batch_file = os.path.join(self.output_dir, f"batch_{batch_num:05d}.jsonl")
-                
-                # Write batch asynchronously
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(None, write_batch_file, batch_file, grouped_records)
                 logger.info(
-                    f"[Batch {batch_num}] Saved {len(grouped_records)} groups "
-                    f"({self.batch_size} groups × {self.num_completions_per_prompt} completions) to {batch_file}"
+                    f"[Batch {batch_num}] Flushed {len(grouped_records)} remaining groups to {batch_file}"
                 )
-            else:
-                pending_groups_count = len(self._pending_groups)
-                complete_count = len(complete_groups)
-                logger.info(
-                    f"[Traj {traj.id}] Added to group {group_id}. "
-                    f"Pending: {pending_groups_count} groups ({complete_count} complete, need {self.batch_size})"
-                )
-
-    async def flush_pending(self):
-        """Flush any remaining records (including incomplete groups) to a final batch file."""
-        async with self._batch_lock:
-            if self._pending_groups:
-                batch_num = self.batch_counter
-                self.batch_counter += 1
-                
-                # Build grouped records from all remaining groups
-                grouped_records = []
-                for g_id, group_records in self._pending_groups.items():
-                    if group_records:
-                        first = group_records[0]
-                        grouped_record = {
-                            "group_id": g_id,
-                            "prompt": first.get("prompt"),
-                            "prompt_ids": first.get("prompt_ids"),
-                            "completions": [r.get("completion") for r in group_records],
-                            "metadata": {
-                                "num_completions": len(group_records),
-                                "timestamp": first.get("metadata", {}).get("timestamp")
-                            }
-                        }
-                        grouped_records.append(grouped_record)
-                self._pending_groups = {}
-                
-                if grouped_records:
-                    batch_file = os.path.join(self.output_dir, f"batch_{batch_num:05d}.jsonl")
-                    
-                    loop = asyncio.get_running_loop()
-                    await loop.run_in_executor(None, write_batch_file, batch_file, grouped_records)
-                    logger.info(f"[Batch {batch_num}] Flushed {len(grouped_records)} remaining groups to {batch_file}")
 
     async def gpu_worker(self, worker_id: int):
         """

--- a/serving/DisTrainer/components/__init__.py
+++ b/serving/DisTrainer/components/__init__.py
@@ -3,3 +3,8 @@ from .checkpoint import CheckpointManager
 from .data_loader import DataLoader
 from .loss import compute_grpo_loss
 from .metrics import MetricsLogger
+
+# Re-export BufferQueue so callers can import it from here
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from buffer_queue import BufferQueue

--- a/serving/DisTrainer/components/data_loader.py
+++ b/serving/DisTrainer/components/data_loader.py
@@ -1,117 +1,165 @@
 """
-DataLoader for consuming JSONL generation files.
-Monitors a directory for new JSONL batches from the Generator.
+DataLoader for consuming GRPO generation batches.
+
+Two modes:
+  Queue mode  – reads from a shared BufferQueue (in-memory deque).
+  File mode   – monitors a directory for new JSONL batches (legacy).
+
+Queue mode is preferred: it removes disk I/O and gives tighter backpressure
+control via the queue's maxlen.
 """
 
 import json
+import sys
+import os
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+# Allow importing BufferQueue from the serving root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from buffer_queue import BufferQueue
+
 
 class DataLoader:
-    """Loads and manages JSONL generation files."""
-    
-    def __init__(self, generations_dir: str):
+    """Loads and manages GRPO generation batches for the trainer."""
+
+    def __init__(
+        self,
+        generations_dir: str,
+        buffer_queue: Optional[BufferQueue] = None,
+        batch_size: int = 10,
+    ):
         """
         Initialize DataLoader.
-        
+
         Args:
             generations_dir: Directory containing JSONL generation files
+                             (used only in file mode).
+            buffer_queue:    Shared BufferQueue instance.  When provided the
+                             loader operates in queue mode and ignores the
+                             filesystem.
+            batch_size:      Number of groups to pull per training step in
+                             queue mode.  In file mode one file = one batch.
         """
+        self.buffer_queue = buffer_queue
+        self.batch_size = batch_size
+
+        # File-mode state
         self.generations_dir = Path(generations_dir)
         self.generations_dir.mkdir(parents=True, exist_ok=True)
         self.processed_files: set = set()
-    
+
+    # ------------------------------------------------------------------
+    # Primary consumer API
+    # ------------------------------------------------------------------
+
     def get_next_batch(self) -> Optional[List[Dict[str, Any]]]:
         """
-        Get the next unprocessed JSONL batch.
-        
-        Returns:
-            List of generation groups, or None if no new data
+        Return the next batch of grouped records, or None if no data is ready.
+
+        Queue mode:  pulls up to `batch_size` groups from BufferQueue; returns
+                     None when the queue is empty so the caller can back-off.
+        File mode:   reads the next unprocessed JSONL file as before.
         """
+        if self.buffer_queue is not None:
+            return self._get_from_queue()
+        return self._get_from_file()
+
+    # ------------------------------------------------------------------
+    # Queue mode
+    # ------------------------------------------------------------------
+
+    def _get_from_queue(self) -> Optional[List[Dict[str, Any]]]:
+        """Pull up to batch_size groups from the BufferQueue."""
+        batch = self.buffer_queue.get_batch(self.batch_size)
+        return batch if batch else None
+
+    # ------------------------------------------------------------------
+    # File mode (legacy)
+    # ------------------------------------------------------------------
+
+    def _get_from_file(self) -> Optional[List[Dict[str, Any]]]:
+        """Get the next unprocessed JSONL batch from disk."""
         available_files = sorted(self.generations_dir.glob("batch_*.jsonl"))
-        
+
         for file in available_files:
             if file not in self.processed_files:
                 groups = self._load_jsonl(file)
                 self.processed_files.add(file)
                 return groups
-        
+
         return None
-    
+
     def _load_jsonl(self, filepath: Path) -> List[Dict[str, Any]]:
         """Load a JSONL file and group completions by group_id."""
         from collections import defaultdict
-        
-        # Read all records
+
         records = []
         with open(filepath, 'r') as f:
             for line in f:
                 line = line.strip()
                 if line:
                     records.append(json.loads(line))
-        
-        # Hashmap to collect completions by group_id
+
         groups = defaultdict(lambda: {"prompt": None, "prompt_ids": None, "completions": []})
-        
+
         for r in records:
             gid = r.get("group_id") or r.get("gen_id")
-            
-            # Store prompt info (only once per group)
+
             if groups[gid]["prompt"] is None:
                 groups[gid]["prompt"] = r.get("prompt")
                 groups[gid]["prompt_ids"] = r.get("prompt_ids")
-            
-            # Collect completions (handle both formats)
+
             if "completion" in r:
                 groups[gid]["completions"].append(r["completion"])
             elif "completions" in r:
                 groups[gid]["completions"].extend(r["completions"])
-        
-        # Convert to list
+
         return [{"gen_id": gid, **data} for gid, data in groups.items()]
-    
+
+    # ------------------------------------------------------------------
+    # Inspection helpers (mirrors the old DataLoader API)
+    # ------------------------------------------------------------------
+
     def count_available(self) -> int:
-        """Count number of unprocessed JSONL files."""
+        """Number of groups / files currently available for training."""
+        if self.buffer_queue is not None:
+            return self.buffer_queue.count_available()
         available_files = sorted(self.generations_dir.glob("batch_*.jsonl"))
-        unprocessed = [f for f in available_files if f not in self.processed_files]
-        return len(unprocessed)
-    
+        return len([f for f in available_files if f not in self.processed_files])
+
     def count_processed(self) -> int:
-        """Count number of processed JSONL files."""
+        """Number of JSONL files processed (file mode only)."""
         return len(self.processed_files)
-    
+
     def reset(self):
-        """Reset processed files tracker (to reprocess all data)."""
+        """Reset processed-files tracker (file mode only)."""
         self.processed_files.clear()
-    
+
     def peek_next_batch(self) -> Optional[List[Dict[str, Any]]]:
         """
-        Peek at the next batch without marking it as processed.
-        
-        Returns:
-            List of generation groups, or None if no new data
+        Peek at the next batch without consuming it.
+
+        Queue mode:  not meaningful (consuming is atomic); returns None.
+        File mode:   returns the next file's contents without marking it done.
         """
+        if self.buffer_queue is not None:
+            return None  # Can't peek a deque non-destructively in queue mode
         available_files = sorted(self.generations_dir.glob("batch_*.jsonl"))
-        
         for file in available_files:
             if file not in self.processed_files:
                 return self._load_jsonl(file)
-        
         return None
-    
+
     def peek_next_batch_file(self) -> Optional[Path]:
         """
-        Get the path to the next unprocessed batch file.
-        
-        Returns:
-            Path to next batch file, or None if no new data
+        Return the path to the next unprocessed batch file (file mode only).
+        Returns None in queue mode.
         """
+        if self.buffer_queue is not None:
+            return None
         available_files = sorted(self.generations_dir.glob("batch_*.jsonl"))
-        
         for file in available_files:
             if file not in self.processed_files:
                 return file
-        
         return None
-

--- a/serving/DisTrainer/trainer.py
+++ b/serving/DisTrainer/trainer.py
@@ -13,7 +13,7 @@ from torch.distributed.checkpoint.state_dict import get_state_dict, StateDictOpt
 
 from .mesh import ParallelDims, build_mesh, init_distributed, is_main_rank
 from .models.parallelization import get_fsdp_strategy, print_trainable_parameters
-from .components import CheckpointManager, DataLoader, compute_grpo_loss, MetricsLogger
+from .components import CheckpointManager, DataLoader, compute_grpo_loss, MetricsLogger, BufferQueue
 from .components.metrics import TrainingMetrics
 
 
@@ -83,7 +83,7 @@ class Trainer:
     Handles FSDP2 setup, training loop, and checkpointing.
     """
 
-    def __init__(self, config: Config, use_base_model: bool = False):
+    def __init__(self, config: Config, use_base_model: bool = False, buffer_queue: Optional[BufferQueue] = None):
         """
         Initialize the Trainer.
 
@@ -126,8 +126,12 @@ class Trainer:
             keep_latest_k=config.checkpoint.keep_latest_k
         )
         
-        # Setup data loader
-        self.data_loader = DataLoader(config.data.generations_dir)
+        # Setup data loader (queue mode when buffer_queue provided, else file mode)
+        self.data_loader = DataLoader(
+            config.data.generations_dir,
+            buffer_queue=buffer_queue,
+            batch_size=config.training.num_generations_per_prompt,
+        )
         
         # Setup metrics logger
         self.metrics_logger = MetricsLogger()

--- a/serving/buffer_queue.py
+++ b/serving/buffer_queue.py
@@ -1,0 +1,186 @@
+"""
+BufferQueue: Async-safe bounded deque for buffering completed GRPO groups
+between the generator and trainer.
+
+Design goals:
+  - Generator (async) calls `await queue.put(group)` after each complete group.
+  - Trainer (sync) calls `queue.get_nowait()` or `queue.get_batch(n)` to pull data.
+  - maxlen caps staleness: when full the *oldest* group is silently evicted so the
+    newest (most on-policy) data always wins. A warning is emitted on each eviction.
+
+Sizing rationale (default maxlen=32):
+  - With batch_size=10 groups per training step this is ~3 full training batches.
+  - Large enough to absorb brief trainer stalls without blocking the generator.
+  - Small enough that data is at most ~3 policy-update versions old before being
+    evicted, keeping training close to on-policy.
+"""
+
+import logging
+import threading
+import time
+from collections import deque
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("BufferQueue")
+
+
+class BufferQueue:
+    """
+    Thread- and async-safe bounded deque for GRPO training groups.
+
+    Each item is a fully-assembled grouped_record dict:
+        {
+            "group_id":   str,
+            "prompt":     str,
+            "prompt_ids": List[int],
+            "completions": [ { "completion_ids", "reward", "old_logprobs", "action_mask" }, ... ],
+            "metadata":   { "num_completions": int, "timestamp": float }
+        }
+
+    Producer (async generator) → put(item)
+    Consumer (sync trainer)    → get_nowait() | get_batch(n)
+    """
+
+    DEFAULT_MAXLEN = 32  # ~3 batches of 10 groups; tune via constructor
+
+    def __init__(self, maxlen: int = DEFAULT_MAXLEN):
+        if maxlen < 1:
+            raise ValueError(f"maxlen must be >= 1, got {maxlen}")
+        self.maxlen = maxlen
+        self._deque: deque = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+        # Counters for observability
+        self._total_put: int = 0
+        self._total_get: int = 0
+        self._dropped: int = 0
+
+        logger.info(f"[BufferQueue] Initialized. maxlen={maxlen}")
+
+    # ------------------------------------------------------------------
+    # Producer API (called from async generator coroutines)
+    # ------------------------------------------------------------------
+
+    async def put(self, item: Dict[str, Any]) -> bool:
+        """
+        Put a completed GRPO group into the queue.
+
+        Because deque(maxlen=N) auto-evicts the *leftmost* (oldest) element
+        when full, we just append — the eviction is implicit. We track whether
+        an eviction occurred so we can warn the caller.
+
+        Returns:
+            True  – item added with no eviction.
+            False – item added but one older item was silently dropped.
+        """
+        with self._lock:
+            evicted = len(self._deque) == self.maxlen
+            if evicted:
+                self._dropped += 1
+                logger.warning(
+                    "[BufferQueue] Queue full (%d/%d). Oldest group evicted "
+                    "(total dropped=%d). Consider slowing generator or speeding trainer.",
+                    self.maxlen, self.maxlen, self._dropped,
+                )
+            self._deque.append(item)
+            self._total_put += 1
+        return not evicted
+
+    # ------------------------------------------------------------------
+    # Consumer API (called from sync trainer / distributed_worker thread)
+    # ------------------------------------------------------------------
+
+    def get_nowait(self) -> Optional[Dict[str, Any]]:
+        """
+        Pop and return the oldest group. Returns None if the queue is empty.
+        Non-blocking; safe to call from any thread.
+        """
+        with self._lock:
+            if self._deque:
+                item = self._deque.popleft()
+                self._total_get += 1
+                return item
+            return None
+
+    def get_batch(self, n: int) -> List[Dict[str, Any]]:
+        """
+        Pop and return up to *n* groups in FIFO order.
+        Returns an empty list if the queue is empty.
+        """
+        with self._lock:
+            count = min(n, len(self._deque))
+            batch = [self._deque.popleft() for _ in range(count)]
+            self._total_get += count
+            return batch
+
+    def wait_for_batch(
+        self,
+        n: int,
+        poll_interval: float = 0.5,
+        timeout: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Blocking helper for the sync trainer: waits until *n* groups are
+        available (or timeout expires) then returns them via get_batch(n).
+
+        Args:
+            n:             Number of groups to wait for.
+            poll_interval: Seconds between availability checks.
+            timeout:       Maximum seconds to wait. None = wait forever.
+
+        Returns:
+            List of up to *n* groups (may be fewer if timeout fired).
+        """
+        deadline = (time.monotonic() + timeout) if timeout is not None else None
+        while True:
+            with self._lock:
+                if len(self._deque) >= n:
+                    break
+            if deadline is not None and time.monotonic() >= deadline:
+                logger.debug("[BufferQueue] wait_for_batch timed out.")
+                break
+            time.sleep(poll_interval)
+        return self.get_batch(n)
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def size(self) -> int:
+        """Current number of groups in the queue."""
+        with self._lock:
+            return len(self._deque)
+
+    @property
+    def is_empty(self) -> bool:
+        return self.size == 0
+
+    @property
+    def is_full(self) -> bool:
+        return self.size == self.maxlen
+
+    def count_available(self) -> int:
+        """Alias for size; mirrors the DataLoader API."""
+        return self.size
+
+    def stats(self) -> Dict[str, Any]:
+        """Return a snapshot of queue statistics for logging / monitoring."""
+        with self._lock:
+            sz = len(self._deque)
+        return {
+            "size": sz,
+            "maxlen": self.maxlen,
+            "fill_pct": round(100.0 * sz / self.maxlen, 1),
+            "total_put": self._total_put,
+            "total_get": self._total_get,
+            "dropped": self._dropped,
+        }
+
+    def __repr__(self) -> str:
+        s = self.stats()
+        return (
+            f"BufferQueue(size={s['size']}/{s['maxlen']} "
+            f"[{s['fill_pct']}%], put={s['total_put']}, "
+            f"get={s['total_get']}, dropped={s['dropped']})"
+        )


### PR DESCRIPTION
## Summary
Introduces an in-memory `BufferQueue` to enable direct async communication between the batch generator and trainer, eliminating disk I/O for GRPO training data. The system now supports two modes: queue-based (preferred) and file-based (legacy fallback).

## Key Changes

- **New `BufferQueue` class** (`serving/buffer_queue.py`):
  - Thread- and async-safe bounded deque with configurable `maxlen` (default 32 groups)
  - Producer API: `await queue.put(group)` for the async generator
  - Consumer API: `get_nowait()`, `get_batch(n)`, and `wait_for_batch(n)` for the trainer
  - Auto-evicts oldest groups when full to maintain on-policy data freshness
  - Comprehensive stats tracking (total put/get, dropped count, fill percentage)

- **Updated `AsyncBatchOrchestrator`** (`serving/DisGenerator/batch_orchestrator.py`):
  - Added optional `buffer_queue` parameter to constructor
  - Refactored `save_trajectory()` to push complete groups directly to queue when available
  - Falls back to file-based batching when `buffer_queue` is `None`
  - Introduced `flush_pending()` to handle incomplete groups at shutdown (pushes to queue or writes final batch file)
  - Improved code formatting and documentation

- **Updated `DataLoader`** (`serving/DisTrainer/components/data_loader.py`):
  - Added optional `buffer_queue` and `batch_size` parameters
  - Dual-mode operation: `_get_from_queue()` for queue mode, `_get_from_file()` for file mode
  - `get_next_batch()` routes to appropriate backend
  - Maintains backward compatibility with file-based workflow

- **Updated `Trainer`** (`serving/DisTrainer/trainer.py`):
  - Added optional `buffer_queue` parameter to constructor
  - Passes queue to `DataLoader` initialization

- **Module exports** (`serving/DisTrainer/components/__init__.py`):
  - Re-exports `BufferQueue` for convenient importing

## Implementation Details

- **Bounded queue design**: The `maxlen` parameter caps memory usage and ensures stale data is evicted, keeping training close to on-policy. Default of 32 groups (~3 training batches) balances absorption of brief stalls with data freshness.
- **Dual-mode architecture**: Generator and trainer can operate independently—queue mode for tight coupling, file mode for decoupled workflows or debugging.
- **Backward compatible**: Existing file-based pipelines continue to work unchanged when `buffer_queue=None`.
- **Observability**: Queue stats (size, fill %, dropped count) logged on each put/flush for monitoring generator-trainer synchronization.

https://claude.ai/code/session_01EaiEiXd5GFfMFLCsS7pRLe